### PR TITLE
Add doxygen documentation for Nasoq

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -281,3 +281,25 @@ target_link_libraries(NASOQ-BIN nasoq_static ${OpenMP_CXX_LIBRARIES})
 #    add_subdirectory(eigen_interface)
 #endif()
 
+# =============================================================================
+#   Add custom target dox_doxygen to generate doxygen documentation for the 
+#   nasoq lib.
+#
+#   Dependencies: doxygen, graphviz.
+# =============================================================================
+find_package(Doxygen)
+if (DOXYGEN_FOUND)
+    set(DOXYGEN_IN ${CMAKE_CURRENT_SOURCE_DIR}/docs/Doxyfile.in)
+    set(DOXYGEN_OUT ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile)
+
+    configure_file(${DOXYGEN_IN} ${DOXYGEN_OUT} @ONLY)
+    message("Doxygen build started")
+
+    add_custom_target( doc_doxygen ALL
+        COMMAND ${DOXYGEN_EXECUTABLE} ${DOXYGEN_OUT}
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+        COMMENT "Generating API documentation with Doxygen"
+        VERBATIM )
+else (DOXYGEN_FOUND)
+  message("Doxygen need to be installed to generate the doxygen documentation")
+endif (DOXYGEN_FOUND)

--- a/docs/Doxyfile.in
+++ b/docs/Doxyfile.in
@@ -1,3 +1,13 @@
+# =============================================================================
+
+PROJECT_NAME           = "NASOQ"
+
+PROJECT_BRIEF          = "Numerically Accurate Sparsity-Oriented QP solver"
+
+PROJECT_LOGO           =
+
+# =============================================================================
+
 OUTPUT_DIRECTORY       = @CMAKE_CURRENT_BINARY_DIR@/doc_doxygen/
 INPUT                  = @CMAKE_CURRENT_SOURCE_DIR@/src/  
 INPUT                 += @CMAKE_CURRENT_SOURCE_DIR@/include/
@@ -7,3 +17,7 @@ INPUT                 += @CMAKE_CURRENT_SOURCE_DIR@/../docs
 RECURSIVE              = YES
 
 EXCLUDE_PATTERNS       = */cxxopts.hpp
+
+# =============================================================================
+
+EXTRACT_ALL            = YES

--- a/docs/Doxyfile.in
+++ b/docs/Doxyfile.in
@@ -1,4 +1,9 @@
 OUTPUT_DIRECTORY       = @CMAKE_CURRENT_BINARY_DIR@/doc_doxygen/
-INPUT                  = @CMAKE_CURRENT_SOURCE_DIR@/src/ @CMAKE_CURRENT_SOURCE_DIR@/include/ @CMAKE_CURRENT_SOURCE_DIR@/../docs
+INPUT                  = @CMAKE_CURRENT_SOURCE_DIR@/src/  
+INPUT                 += @CMAKE_CURRENT_SOURCE_DIR@/include/
+INPUT                 += @CMAKE_CURRENT_SOURCE_DIR@/smp-format/
+INPUT                 += @CMAKE_CURRENT_SOURCE_DIR@/../docs
 
 RECURSIVE              = YES
+
+EXCLUDE_PATTERNS       = */cxxopts.hpp

--- a/docs/Doxyfile.in
+++ b/docs/Doxyfile.in
@@ -1,0 +1,4 @@
+OUTPUT_DIRECTORY       = @CMAKE_CURRENT_BINARY_DIR@/doc_doxygen/
+INPUT                  = @CMAKE_CURRENT_SOURCE_DIR@/src/ @CMAKE_CURRENT_SOURCE_DIR@/include/ @CMAKE_CURRENT_SOURCE_DIR@/../docs
+
+RECURSIVE              = YES


### PR DESCRIPTION
Added custom target doc_doxygen in CMakeLists.txt to generate doxygen documentation for Nasoq. 

Dependencies for generating the documentation include:
* doxygen
* graphviz

To generate the documentation, one can simply run ```cmake <...>``` to configure the project and then ```make``` or ```cmake --build . --target doc_doxygen```.

The generated documentations locate in ```<build dir>/doc_doxygen```.

Currently, most functions in NASOQ are not documented. Doxygen is still able to pick up dependencies in code and generate documentation like:

![image](https://user-images.githubusercontent.com/33966589/116189924-b3497200-a6f7-11eb-90c8-73741561cd7b.png)
