### PR TITLE
Fixes for Windows compilation

### DIFF
--- a/include/common/Norm.h
+++ b/include/common/Norm.h
@@ -7,6 +7,7 @@
 
 #include <cmath>
 #include <iostream>
+#include <algorithm>
 
 namespace nasoq {
  double norm_dense
@@ -89,4 +90,5 @@ namespace nasoq {
 
  double cs_norm1(int n, int *Ap, int *Ai, double *Ax);
 }
+
 #endif //PROJECT_NORM_H

--- a/smp-format/def.h
+++ b/smp-format/def.h
@@ -191,11 +191,11 @@
     if(n != in_c->n || m != in_c->m || nnz != in_c->nnz)
      return false;
     for (int j = 0; j < n+1; ++j) {
-     if(!is_equal(p[j], in_c->p[j]))
+     if(p[j] != in_c->p[j])
       return false;
     }
     for (int j = 0; j < nnz; ++j) {
-     if(!is_equal(i[j], in_c->i[j]) || !is_equal(x[j], in_c->x[j]))
+     if((i[j] != in_c->i[j]) || (x[j] != in_c->x[j]))
       return false;
     }
     return true;


### PR DESCRIPTION
I've pushed a few fixes I needed to make to get the code to compile on Windows (Visual Studio 16, 2019).

1. std::min and std::max require \<algorithm\>
2. There is some code that calls is_equal on pairs of ints. The issue is that is_equal calls is_nan, which does not compile on integer types because MSVC does not know how which floating-point type to cast the int to. I removed the use of is_equal; an alternative fix would be to specialize the is_nan template for int.

There is another issue, not included in this pull request: the version of Metis that is automatically downloaded by your build script does not compile on modern Windows, due to this issue: https://github.com/jlblancoc/suitesparse-metis-for-windows/issues/19

This problem is not your fault, but just FYI that Windows users may not be able to compile NASOQ out of the box without Googling and fixing this problem.