### PR TITLE
removed outdated debug code

### DIFF
--- a/.github/workflows/WindowsBuild.yml
+++ b/.github/workflows/WindowsBuild.yml
@@ -37,7 +37,7 @@ jobs:
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-      run: cmake -DNASOQ_BLAS_BACKEND=OpenBLAS -DNASOQ_USE_CLAPACK=ON -DCMAKE_BUILD_TYPE=Release  -B ${{github.workspace}}\build 
+      run: cmake -DNASOQ_BLAS_BACKEND=OpenBLAS -DNASOQ_USE_CLAPACK=ON -DNASOQ_BUILD_DOCS=OFF -DCMAKE_BUILD_TYPE=Release  -B ${{github.workspace}}\build 
 
           
           

--- a/include/nasoq/ldl/Serial_blocked_ldl_02.h
+++ b/include/nasoq/ldl/Serial_blocked_ldl_02.h
@@ -69,11 +69,6 @@ bool ldl_left_sn_02(int n, int* c, int* r, double* values,
      //      printf("dddd\n");
     }
    }
-#if DEBUG
-   top = ereach_sn(supNo,c,r,curCol,nxtCol,col2sup, eTree,xi,xi+supNo);
-         if(supNo-top != prunePtr[s]-prunePtr[s-1])
-             printf("sss");
-#endif
    double *src, *cur = &lValues[lC[curCol]];//pointing to first element of the current supernode
 
 /*  if(curCol == 36)

--- a/src/common/Reach.cpp
+++ b/src/common/Reach.cpp
@@ -53,12 +53,6 @@ namespace nasoq {
     PBset[PBsize++] = col2sup[xi[i]];
    }
   }
-#if DEBUG > 0
-  for(int i=0; i<PBsize; i++){
-         std::cout<<PBset[i]<<",";
-     }
-     std::cout<<"\n";
-#endif
   delete[]checked;
   delete[]xi;
   return (PBsize);

--- a/src/common/TreeUtils.cpp
+++ b/src/common/TreeUtils.cpp
@@ -121,16 +121,6 @@ namespace nasoq {
      nChild[inTree[cc]]--;
    }
   }
-#if DEBUG >= 2
-  std::cout<<"FinalSet\n";
-  for (int l = 0; l < curLevel; ++l) {
-   for (int lp = levelPtr[l]; lp < levelPtr[l+1]; ++lp) {
-    std::cout<<levelSet[lp]<<",";
-   }
-   std::cout<<"\n\n";
-  }
-  std::cout<<"\n";
-#endif
   delete[]nChild;
   delete[]visited;
   return curLevel;
@@ -141,12 +131,6 @@ namespace nasoq {
                     std::vector<std::vector<int>> &mergedLeveledParList, int *outCost, int costThreshold) {
   int lClusterCnt = 0;
   int partNo = newLeveledParList.size();
-#ifdef DEBUG
-  for (int j = 0; j < partNo; ++j) {
-         std::cout<<inCost[j]<<",";
-     }
-     std::cout<<"\n";
-#endif
   for (int i = 0; i < partNo;) {
    int curCost = 0;
    while (curCost < (1 * costThreshold) && i < partNo) {

--- a/src/ldl/Serial_blocked_ldl.cpp
+++ b/src/ldl/Serial_blocked_ldl.cpp
@@ -55,11 +55,6 @@ namespace nasoq {
      //      printf("dddd\n");
     }
    }
-#if DEBUG
-   top = ereach_sn(supNo,c,r,curCol,nxtCol,col2sup, eTree,xi,xi+supNo);
-         if(supNo-top != prunePtr[s]-prunePtr[s-1])
-             printf("sss");
-#endif
    double *src, *cur = &lValues[lC[curCol]];//pointing to first element of the current supernode
 
 #ifndef PRUNE
@@ -74,11 +69,6 @@ namespace nasoq {
        int lSN = pruneSet[i];
 #endif
     int nSupRs = 0;
-#if DEBUG
-    if(xi[top++] != lSN)
-                 printf("fail");
-#endif
-
     int cSN = blockSet[lSN];//first col of current SN
     int cNSN = blockSet[lSN + 1];//first col of Next SN
     int Li_ptr_cNSN = Li_ptr[cNSN];

--- a/src/ldl/Serial_update_ldl_static.cpp
+++ b/src/ldl/Serial_update_ldl_static.cpp
@@ -65,11 +65,6 @@ namespace nasoq {
      //      printf("dddd\n");
     }
    }
-#if DEBUG
-   top = ereach_sn(supNo,c,r,curCol,nxtCol,col2sup, eTree,xi,xi+supNo);
-         if(supNo-top != prunePtr[s]-prunePtr[s-1])
-             printf("sss");
-#endif
    top = ereach_sn(supNo, cT, rT, curCol, nxtCol, col2Sup, aTree, xi, xi + supNo);
    assert(top >= 0);
    //std::cout<<"--> "<<s-1<<";;";
@@ -78,10 +73,6 @@ namespace nasoq {
     int lSN = xi[i];
     //std::cout<<lSN<<";";
     int nSupRs = 0;
-#if DEBUG
-    if(xi[top++] != lSN)
-                 printf("fail");
-#endif
     int cSN = blockSet[lSN];//first col of current SN
     int cNSN = blockSet[lSN + 1];//first col of Next SN
     int Li_ptr_cNSN = Li_ptr[cNSN];

--- a/src/ldl/parallel_blocked_ldlt.cpp
+++ b/src/ldl/parallel_blocked_ldlt.cpp
@@ -83,11 +83,6 @@ namespace nasoq {
         //      printf("dddd\n");
        }
       }
-#if DEBUG
-      top = ereach_sn(supNo,c,r,curCol,nxtCol,col2sup, eTree,xi,xi+supNo);
-            if(supNo-top != prunePtr[s]-prunePtr[s-1])
-                printf("sss");
-#endif
       double *src, *cur = &lValues[lC[curCol]];//pointing to first element of the current supernode
 
 //#ifndef PRUNE
@@ -101,10 +96,6 @@ namespace nasoq {
          int lSN = pruneSet[i];
 #endif*/
        int nSupRs = 0;
-#if DEBUG
-       if(xi[top++] != lSN)
-                    printf("fail");
-#endif
        int cSN = blockSet[lSN];//first col of current SN
        int cNSN = blockSet[lSN + 1];//first col of Next SN
        int Li_ptr_cNSN = Li_ptr[cNSN];
@@ -248,11 +239,6 @@ namespace nasoq {
       //      printf("dddd\n");
      }
     }
-#if DEBUG
-    top = ereach_sn(supNo,c,r,curCol,nxtCol,col2sup, eTree,xi,xi+supNo);
-            if(supNo-top != prunePtr[s]-prunePtr[s-1])
-                printf("sss");
-#endif
     double *src, *cur = &lValues[lC[curCol]];//pointing to first element of the current supernode
 
 //#ifndef PRUNE
@@ -266,10 +252,6 @@ namespace nasoq {
          int lSN = pruneSet[i];
 #endif*/
      int nSupRs = 0;
-#if DEBUG
-     if(xi[top++] != lSN)
-                    printf("fail");
-#endif
      int cSN = blockSet[lSN];//first col of current SN
      int cNSN = blockSet[lSN + 1];//first col of Next SN
      int Li_ptr_cNSN = Li_ptr[cNSN];

--- a/src/ldl/parallel_blocked_ldlt_03.cpp
+++ b/src/ldl/parallel_blocked_ldlt_03.cpp
@@ -92,11 +92,6 @@ namespace nasoq {
         //      printf("dddd\n");
        }
       }
-#if DEBUG
-      top = ereach_sn(supNo,c,r,curCol,nxtCol,col2sup, eTree,xi,xi+supNo);
-            if(supNo-top != prunePtr[s]-prunePtr[s-1])
-                printf("sss");
-#endif
       double *src, *cur = &lValues[lC[curCol]];//pointing to first element of the current supernode
 
 //#ifndef PRUNE
@@ -110,10 +105,6 @@ namespace nasoq {
          int lSN = pruneSet[i];
 #endif*/
        int nSupRs = 0;
-#if DEBUG
-       if(xi[top++] != lSN)
-                    printf("fail");
-#endif
        int cSN = blockSet[lSN];//first col of current SN
        int cNSN = blockSet[lSN + 1];//first col of Next SN
        int Li_ptr_cNSN = Li_ptr[cNSN];
@@ -407,11 +398,6 @@ namespace nasoq {
       //      printf("dddd\n");
      }
     }
-#if DEBUG
-    top = ereach_sn(supNo,c,r,curCol,nxtCol,col2sup, eTree,xi,xi+supNo);
-            if(supNo-top != prunePtr[s]-prunePtr[s-1])
-                printf("sss");
-#endif
     double *src, *cur = &lValues[lC[curCol]];//pointing to first element of the current supernode
 
  //#ifndef PRUNE
@@ -425,10 +411,6 @@ namespace nasoq {
           int lSN = pruneSet[i];
  #endif*/
      int nSupRs = 0;
-#if DEBUG
-     if(xi[top++] != lSN)
-                    printf("fail");
-#endif
      int cSN = blockSet[lSN];//first col of current SN
      int cNSN = blockSet[lSN + 1];//first col of Next SN
      int Li_ptr_cNSN = Li_ptr[cNSN];


### PR DESCRIPTION
Removed debug code. Most of the debug code won't compile out of the box, it references variables that don't exist. I'm guessing it's outdated and was never detected since `DEBUG` is not defined. 
Some of it will not compile because it uses `std::cout` but `iostream` is not included. I removed this too.