### PR TITLE
Remove double semicolons

### DIFF
--- a/include/nasoq/QP/qp_utils.h
+++ b/include/nasoq/QP/qp_utils.h
@@ -105,7 +105,7 @@ namespace nasoq {
   double factt, init;
   int num_update, num_downdate, num_refactor, num_solve;
 
-  qp_info();;
+  qp_info();
 
   std::chrono::time_point<std::chrono::system_clock> tic();
 

--- a/include/nasoq/nasoq.h
+++ b/include/nasoq/nasoq.h
@@ -52,7 +52,7 @@ namespace nasoq {
   int inner_iter, outer_iter;
   double pert_diag, stop_tol;
 
-  nasoq_config(int a, int b, double c, double d);;
+  nasoq_config(int a, int b, double c, double d);
  };
 
 /*


### PR DESCRIPTION
The extra semicolons cause some compiler warnings when building with `-pedantic`